### PR TITLE
Fix retrieval of html document from text buffer

### DIFF
--- a/src/TextViewCreationListener.cs
+++ b/src/TextViewCreationListener.cs
@@ -16,7 +16,7 @@ namespace ErrorCatcher
 
         public void TextViewCreated(IWpfTextView textView)
         {
-            if (!DocumentService.TryGetTextDocument(textView.TextBuffer, out var doc) || ErrorProcessor.Instance == null)
+            if (!DocumentService.TryGetTextDocument(textView.TextDataModel.DocumentBuffer, out var doc) || ErrorProcessor.Instance == null)
                 return;
 
             textView.Properties.AddProperty("filePath", doc.FilePath);


### PR DESCRIPTION
Certain tag-based file types (config files, razor views, html, etc.) were not showing errors in VS 2017. I narrowed it down to a null returned on the call to TryGetTextDocument for those file types. After some research, I changed the text buffer parameter, which seems to fix the issue. Please let me know if I'm off on this!